### PR TITLE
Add cleaner error handling

### DIFF
--- a/handlers/error.py
+++ b/handlers/error.py
@@ -3,7 +3,11 @@ from templating import render_template
 from db.models import User
 
 def error_handler(request):
+    create_error(request, "404 Error!")
+    
+def create_error(request, message):
     request.set_status(404)
+
     u_id = request.get_secure_cookie('user_id')
     u_name = ""
     if u_id is not None:
@@ -11,5 +15,5 @@ def error_handler(request):
         u_name = User.find(user_id=u_id)
         u_name = u_name.username
 
-    error_page = render_template(template_paths["error"], {"user_name": u_name})
+    error_page = render_template(template_paths["error"], {"user_name": u_name, "error": message})
     request.write(error_page)

--- a/handlers/game.py
+++ b/handlers/game.py
@@ -2,6 +2,7 @@ from db.models import User, Game
 from templating import render_template
 from db.models import User
 from . import template_paths
+from .error import create_error
 
 import random
 
@@ -36,7 +37,7 @@ def get_question_handler(request, question_index):
 
     game_id = request.get_secure_cookie('game_id')
     if not game_id:
-        request.redirect("/404punk")
+        create_error(request, "You aren't in a game!")
         return
 
     game_id = game_id.decode()
@@ -44,14 +45,15 @@ def get_question_handler(request, question_index):
     if game:
         question = game.get_question(int(question_index))
         if not question:
-            request.write("that question does not exist")
+            create_error(request, "That question doesn't exist!")
             return
         answers = game.get_answers(game.question_ids[int(question_index)])
         random.shuffle(answers)
         request.write(render_template(template_paths["questions"],
             {"question": question, "answers": answers, "question_index": str(int(question_index)+1), "user_name":u_name}))
         return
-    request.redirect("/404kid")
+    
+    create_error(request, "Could not handle that question!")
 
 def submit_question_handler(request, answer_id):
     game_id = request.get_secure_cookie("game_id")

--- a/templates/error.html
+++ b/templates/error.html
@@ -11,7 +11,7 @@
 				
 			</div>
 			<h1 class="error_title">
-					404 ERROR!
+					{{ error }}
 			</h1>
 			
 			<p> You seem to be experiencing some trouble with the site - how about you go back to to the home page and try again? <br> You can use the links at the top of the page...

--- a/trivia.py
+++ b/trivia.py
@@ -18,7 +18,7 @@ from handlers.leaderboard import leaderboard_handler
 from handlers.category import category_handler, category_list_handler
 from handlers.question import new_question_handler, new_question_form, edit_question_handler
 from handlers.logout import logout_handler
-from handlers.error import error_handler
+from handlers.error import error_handler, create_error
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -47,6 +47,7 @@ server.register('/user', user_handler, post=signup_handler_post)
 # server.register('/user/([0-9]+)', edit_user_handler)
 server.register('/categories', category_list_handler)
 server.register('/logout', logout_handler)
+server.register('/error/(.*)', create_error)
 server.register('/.*', error_handler)
 
 if __name__ == '__main__':


### PR DESCRIPTION
TLDRCM (too lazy don't read commit messages):
- add a create_error function to handlers/errors, which given a string and request will construct an error page!
- add a (coined term), error dumping ground. Basically call to /error/(.*) and the captured string will be used as an error message :)
